### PR TITLE
Add some configuration keys

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,54 @@
 var gulp    = require("gulp");
+var tinyLr = require('tiny-lr');
+var express = require ("express");
+var uglify = require("gulp-uglify");
 var concat  = require("gulp-concat");
 var clean   = require("gulp-rimraf");
 var files   = require("./files.json");
+var runSequence = require('run-sequence');
 var ngHtml2Js = require("gulp-ng-html2js");
 var minifyHtml = require("gulp-minify-html");
-var uglify = require("gulp-uglify");
+
+var lr;
+
+var EXPRESS_PORT = 8000;
+var EXPRESS_ROOT = __dirname + "/dist";
+var LIVERELOAD_PORT = 35729;
+
+function startLiveReload(){
+  lr = tinyLr();  
+  lr.listen(LIVERELOAD_PORT);
+}
+
+function startServer(){
+  var app = express();
+  console.log (EXPRESS_ROOT);
+  app.use(express.static(EXPRESS_ROOT));
+  app.listen(EXPRESS_PORT);
+}
+
+function notifyLivereload(event) {
+  runSequence(["clean", 
+    "styles", 
+    "libs",
+    "src",
+    "fonts"
+    ], function(){
+
+      var fileName = require("path").relative(EXPRESS_ROOT, event.path);
+ 
+      lr.changed({
+        body: {
+          files: [fileName]
+        }
+      });
+
+    });
+}
+
+gulp.task("serve", function(){
+  startServer();
+});
 
 gulp.task("clean", function() {
   return gulp.src(["dist/*"], {read:false}).pipe(clean());
@@ -56,11 +100,10 @@ gulp.task("src", ["html", "images"], function() {
   .pipe(gulp.dest("./dist"))
 });
 
+gulp.task("watch", function(){
+  startServer();
+  startLiveReload();
+  gulp.watch(["src/**", "src/**/**"], notifyLivereload);
+});
 
-gulp.task("default", [
-    "clean", 
-    "styles", 
-    "libs",
-    "src",
-    "fonts"
-    ]);
+gulp.task("default", ["clean", "styles", "libs", "src", "fonts"]);

--- a/package.json
+++ b/package.json
@@ -4,18 +4,22 @@
   "description": "BlankOn Installer UI",
   "main": "gulpfile.js",
   "scripts": {
-    "start" : "(cd dist; python -m SimpleHTTPServer)",
+    "start": "gulp && gulp watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Mohammad Anwari <mdamt@mdamt.net>",
   "license": "MIT",
   "devDependencies": {
+    "connect-livereload": "^0.4.0",
+    "express": "^4.7.2",
     "gulp": "3.8.7",
-    "gulp-rimraf": "^0.1.0",
     "gulp-concat": "~2.2.0",
     "gulp-minify-html": "^0.1.4",
     "gulp-ng-html2js": "^0.1.7",
-    "gulp-uglify": "^0.3.1"
+    "gulp-rimraf": "^0.1.0",
+    "gulp-uglify": "^0.3.1",
+    "run-sequence": "^0.3.6",
+    "tiny-lr": "0.0.9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Add local gulp copy at `package.json` to get rid `Local gulp not found in current dir` error
2. Replace the deprecated `gulp-clean` with `gulp-rimraf`
3. Add some info (repo, bugs, homepage, keywords) in `package.json`
4. Add start script to `package.json`, hence we can do `npm start`
5. Livereload support (on chrome https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei, please let the port 35729 free). Activate the server via `$ gulp watch`
